### PR TITLE
Simplify and clarify game issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.md
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.md
@@ -20,7 +20,9 @@ about: Report a game's compatibility status on Ryujinx
 
 
 *Describe the current game state here. 
-List the issues you've noticed if there are any. Add links to pull requests that fix issues described if/when applicable. 
+List the issues you've noticed if there are any. 
+Add links to related issues from the main repository if they exist.
+Add links to pull requests that fix issues described if/when applicable. 
 Add a zipped save file for easy access to any issues if needed, namely for situations that can only be accessed after several hours of gameplay.*
 
 ```

--- a/.github/ISSUE_TEMPLATE/game_compatibility.md
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.md
@@ -6,47 +6,38 @@ about: Report a game's compatibility status on Ryujinx
 
 ## Game Name
 
-#### Game Update Version : *(e.g. 1.0.0 or 1.1.3)*
+#### Game Update Version: *(e.g. 1.0.0 or 1.1.3)*
 
-#### Current on `master` : Emulator Build Version : *(e.g. 1.1.202)*
+#### Emulator Build Version: *(e.g. 1.1.373)*
 
-#### Graphics Backend : *(e.g. Vulkan or OpenGL)*
+#### Graphics Backend: *(e.g. Vulkan or OpenGL)*
 
-*Describe the current game state here.*
-
-```
-Last error returned.
-e.g.: Unhandled Exception: System.NotImplementedException: /dev/nvhost-nvdec 40044801
-```
-
-#### Hardware Specs : 
+#### Hardware Specs: 
 
 ##### CPU: *(e.g. i7-6700)*
 ##### GPU: *(e.g. NVIDIA RTX 2070)*
 ##### RAM: *(e.g. 16GB)*
 
-#### Pull requests needed :
 
-*Add needed PR links here.*
+*Describe the current game state here. 
+List the issues you've noticed if there are any. Add links to pull requests that fix issues described if/when applicable. 
+Add a zipped save file for easy access to any issues if needed, namely for situations that can only be accessed after several hours of gameplay.*
 
-*(Optional section, remove it if unneeded)*
+```
+Last error returned.
+Add the last error in the log if there is any.
+e.g.: Unhandled Exception: System.NotImplementedException: /dev/nvhost-nvdec 40044801
+```
 
-#### Outstanding Issues:
 
-*Add issue links here.*
+#### Screenshots:
 
-*Example: https://github.com/Ryujinx/Ryujinx/issues/xxx (xxx = number issue)*
+*Add screenshots here (preferably on windowed mode) if the game is rendering.*
 
-*(Optional section, remove it if unneeded)*
 
-#### Screenshots :
+#### Log file:
 
-*Add screenshots here if the game rendering something.*
+*Add a log file here. 
+Can be found in the logs folder, in the same directory as the Ryujinx executable, or through File > Open logs folder.*
 
-*(Optional section, remove it if unneeded)*
 
-#### Log file :
-
-*Add a link to the log file here.*
-
-*(Optional section, remove it if unneeded)*


### PR DESCRIPTION
Debating whether or not an "OS" line should be added under CPU, GPU and RAM.

Removed "current on master" as it was redundant with "emulator build version", and the latter is more understandable for most, though I'm open to keeping "current on master". 

Moved "hardware specs" up for better readability.

Removed "pull requests needed" as nobody uses that anymore (not as a different section at least, no point in doing that) and added it to the game state description.

Removed "outstanding issues" as we're no longer taking game-specific issues on the main repository.

Expanded on "describe the current state of the game" to make up for the above change.

Specified that game screenshots are preferable on windowed mode.

Specified how to access log files.

Removed the "optional" from screenshots and logs, as a lot of reports end up needing them for more information.

Removed spaces before colons.