### PR TITLE
Add GPU Driver version as a requirment for reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -39,6 +39,7 @@ body:
       value: |
         - ##### CPU: *(e.g. i7-6700)*
         - ##### GPU: *(e.g. NVIDIA RTX 2070)*
+        - ##### Driver version: *(e.g. 545.84)*
         - ##### RAM: *(e.g. 16GB)*
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -39,7 +39,7 @@ body:
       value: |
         - ##### CPU: *(e.g. i7-6700)*
         - ##### GPU: *(e.g. NVIDIA RTX 2070)*
-        - ##### Driver version: *(e.g. 545.84)*
+        - ##### GPU Driver version: *(e.g. 545.84)*
         - ##### RAM: *(e.g. 16GB)*
     validations:
       required: true


### PR DESCRIPTION
There's been a lot of people with not updated drivers in Github Compatibility list and its hard to pinpoint if a bug reported is actually caused by the outdated driver or if its a legitimate issue a game has.

This just adds another line of text in Hardware Specs that asks for driver version of the GPU that's being used.
That way its gonna be easier to help other people if a driver is outdated and it will help to pinpoint if a bug happened because of a new version of the driver or not.