### PR TITLE
Logfile requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/game_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/game_compatibility.yml
@@ -71,4 +71,4 @@ body:
       description: Logs files can be found under the "Logs" subfolder in the Ryujinx program folder. 
       placeholder: Drag and drop the log file onto the text area.
     validations:
-      required: false
+      required: true


### PR DESCRIPTION
Making logfile a requirement as there should be no real need to submit a report without one and if needed and always put `N/A`